### PR TITLE
ci: add GitHub Pages workflow for metaball demo

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,38 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+    paths: [assets/metaball-demo.html]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Prepare site
+        run: |
+          mkdir _site
+          cp assets/metaball-demo.html _site/index.html
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary

- Adds a GitHub Actions workflow that deploys `assets/metaball-demo.html` as the site index to GitHub Pages
- Triggers on changes to the demo file or via manual dispatch
- Pages source set to "GitHub Actions" (already enabled via API)

Once merged, the demo will be live at https://garthdb.github.io/ferrograph/ (or garthdb.com/ferrograph if custom domain is configured).

Made with [Cursor](https://cursor.com)