### PR TITLE
feat(cli): named subcommands, --json flag, richer status, dead code symbols

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -205,7 +205,14 @@ fn run_query(db: Option<&PathBuf>, query: &str, json: bool) -> Result<()> {
         println!("{}", serde_json::to_string_pretty(&result)?);
     } else {
         for row in &result.rows {
-            println!("{}", row.join("\t"));
+            let cols: Vec<String> = row
+                .iter()
+                .map(|v| match v {
+                    serde_json::Value::String(s) => s.clone(),
+                    other => other.to_string(),
+                })
+                .collect();
+            println!("{}", cols.join("\t"));
         }
     }
     Ok(())

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,9 +11,13 @@ use clap::{Parser, Subcommand};
     name = "ferrograph",
     version,
     about,
-    long_version = include_str!("../assets/ascii-banner.txt")
+    long_version = concat!(include_str!("../assets/ascii-banner.txt"), "\n  v", env!("CARGO_PKG_VERSION"))
 )]
 pub struct Cli {
+    /// Output JSON instead of human-readable text.
+    #[arg(long, global = true)]
+    pub json: bool,
+
     #[command(subcommand)]
     pub command: Command,
 }
@@ -63,6 +67,59 @@ pub enum Command {
         #[arg(short, long, required = true)]
         output: Option<PathBuf>,
     },
+    /// Find dead (unreachable) code.
+    Dead {
+        /// Path to the graph database.
+        #[arg(short, long)]
+        db: Option<PathBuf>,
+        /// Filter results by file glob pattern.
+        #[arg(short, long)]
+        file: Option<String>,
+    },
+    /// Show blast radius (transitive impact) of a node.
+    Blast {
+        /// Path to the graph database.
+        #[arg(short, long)]
+        db: Option<PathBuf>,
+        /// Node ID to compute blast radius from.
+        node_id: String,
+    },
+    /// Show callers of a node (reverse call graph).
+    Callers {
+        /// Path to the graph database.
+        #[arg(short, long)]
+        db: Option<PathBuf>,
+        /// Node ID to find callers for.
+        node_id: String,
+        /// Maximum call depth (default: 1 = direct callers only).
+        #[arg(long, default_value = "1")]
+        depth: u32,
+    },
+    /// Show full info for a node (type, payload, edges).
+    Info {
+        /// Path to the graph database.
+        #[arg(short, long)]
+        db: Option<PathBuf>,
+        /// Node ID to inspect.
+        node_id: String,
+    },
+    /// Show module containment graph.
+    Modules {
+        /// Path to the graph database.
+        #[arg(short, long)]
+        db: Option<PathBuf>,
+        /// Filter to modules under this path prefix (e.g. "./src/").
+        #[arg(short, long)]
+        root: Option<String>,
+    },
+    /// Show trait implementors.
+    Traits {
+        /// Path to the graph database.
+        #[arg(short, long)]
+        db: Option<PathBuf>,
+        /// Trait name to search for.
+        trait_name: String,
+    },
     /// Run the MCP server over stdio (for AI agents and IDEs).
     Mcp,
 }
@@ -72,16 +129,23 @@ pub enum Command {
 /// # Errors
 /// Returns an error if the selected command fails (e.g. I/O or graph errors).
 pub fn run(cli: Cli) -> Result<()> {
+    let json = cli.json;
     match cli.command {
         Command::Index { path, output } => run_index(&path, output.as_ref()),
-        Command::Query { db, query } => run_query(db.as_ref(), &query),
+        Command::Query { db, query } => run_query(db.as_ref(), &query, json),
         Command::Search {
             db,
             query,
             case_insensitive,
-        } => run_search(db.as_ref(), &query, case_insensitive),
-        Command::Status { path } => run_status(&path),
+        } => run_search(db.as_ref(), &query, case_insensitive, json),
+        Command::Status { path } => run_status(&path, json),
         Command::Watch { path, output } => run_watch(&path, output.as_ref()),
+        Command::Dead { db, file } => run_dead(db.as_ref(), file.as_deref(), json),
+        Command::Blast { db, node_id } => run_blast(db.as_ref(), &node_id, json),
+        Command::Callers { db, node_id, depth } => run_callers(db.as_ref(), &node_id, depth, json),
+        Command::Info { db, node_id } => run_info(db.as_ref(), &node_id, json),
+        Command::Modules { db, root } => run_modules(db.as_ref(), root.as_deref(), json),
+        Command::Traits { db, trait_name } => run_traits(db.as_ref(), &trait_name, json),
         Command::Mcp => run_mcp(),
     }
 }
@@ -125,7 +189,7 @@ fn run_index(path: &Path, output: Option<&PathBuf>) -> Result<()> {
     Ok(())
 }
 
-fn run_query(db: Option<&PathBuf>, query: &str) -> Result<()> {
+fn run_query(db: Option<&PathBuf>, query: &str, json: bool) -> Result<()> {
     let db_path = resolve_db_path(db)?;
     if !db_path.exists() {
         anyhow::bail!(
@@ -136,23 +200,18 @@ fn run_query(db: Option<&PathBuf>, query: &str) -> Result<()> {
     }
     let store = crate::graph::Store::new_persistent(&db_path)
         .with_context(|| format!("Failed to open graph at {}", db_path.display()))?;
-    let params = std::collections::BTreeMap::new();
-    let script = if query.contains(":limit") {
-        query.trim().to_string()
+    let result = crate::ops::query(&store, query).context("Query execution failed")?;
+    if json {
+        println!("{}", serde_json::to_string_pretty(&result)?);
     } else {
-        format!("{}\n:limit 10000", query.trim())
-    };
-    let rows = store
-        .run_query(&script, params)
-        .context("Query execution failed")?;
-    for row in &rows.rows {
-        let line: Vec<String> = row.iter().map(std::string::ToString::to_string).collect();
-        println!("{}", line.join("\t"));
+        for row in &result.rows {
+            println!("{}", row.join("\t"));
+        }
     }
     Ok(())
 }
 
-fn run_search(db: Option<&PathBuf>, query: &str, case_insensitive: bool) -> Result<()> {
+fn run_search(db: Option<&PathBuf>, query: &str, case_insensitive: bool, json: bool) -> Result<()> {
     let db_path = resolve_db_path(db)?;
     if !db_path.exists() {
         anyhow::bail!(
@@ -163,10 +222,14 @@ fn run_search(db: Option<&PathBuf>, query: &str, case_insensitive: bool) -> Resu
     }
     let store = crate::graph::Store::new_persistent(&db_path)
         .with_context(|| format!("Failed to open graph at {}", db_path.display()))?;
-    let (rows, _total) = crate::search::text_search(&store, query, case_insensitive, 10_000, 0)?;
-    for (id, node_type, payload) in rows {
-        let payload_display = payload.as_deref().unwrap_or("—");
-        println!("{id}\t{node_type}\t{payload_display}");
+    let result = crate::ops::search(&store, query, case_insensitive, 10_000, 0)?;
+    if json {
+        println!("{}", serde_json::to_string_pretty(&result)?);
+    } else {
+        for item in &result.results {
+            let payload_display = item.payload.as_deref().unwrap_or("—");
+            println!("{}\t{}\t{payload_display}", item.id, item.node_type);
+        }
     }
     Ok(())
 }
@@ -180,7 +243,185 @@ fn run_watch(path: &Path, output: Option<&PathBuf>) -> Result<()> {
     crate::watch::watch_and_reindex(&store, path, &config)
 }
 
-fn run_status(path: &Path) -> Result<()> {
+fn run_dead(db: Option<&PathBuf>, file: Option<&str>, json: bool) -> Result<()> {
+    let db_path = resolve_db_path(db)?;
+    if !db_path.exists() {
+        anyhow::bail!(
+            "Graph database not found at {}. Run 'ferrograph index --output {}' first.",
+            db_path.display(),
+            db_path.display()
+        );
+    }
+    let store = crate::graph::Store::new_persistent(&db_path)
+        .with_context(|| format!("Failed to open graph at {}", db_path.display()))?;
+    let result = crate::ops::dead_code(&store, file)?;
+    if json {
+        println!("{}", serde_json::to_string_pretty(&result)?);
+    } else {
+        for node in &result.dead_nodes {
+            let payload = node.payload.as_deref().unwrap_or("—");
+            println!("{}\t{}\t{payload}", node.id, node.node_type);
+        }
+        println!(
+            "\n{} dead nodes found (source: {})",
+            result.count, result.source
+        );
+        println!("\n{}", crate::ops::DEAD_CODE_CAVEAT);
+    }
+    Ok(())
+}
+
+fn run_blast(db: Option<&PathBuf>, node_id: &str, json: bool) -> Result<()> {
+    let db_path = resolve_db_path(db)?;
+    if !db_path.exists() {
+        anyhow::bail!(
+            "Graph database not found at {}. Run 'ferrograph index --output {}' first.",
+            db_path.display(),
+            db_path.display()
+        );
+    }
+    let store = crate::graph::Store::new_persistent(&db_path)
+        .with_context(|| format!("Failed to open graph at {}", db_path.display()))?;
+    let result = crate::ops::blast_radius(&store, node_id)?;
+    if json {
+        println!("{}", serde_json::to_string_pretty(&result)?);
+    } else {
+        for node in &result.reachable_nodes {
+            let payload = node.payload.as_deref().unwrap_or("—");
+            println!("{}\t{}\t{payload}", node.id, node.node_type);
+        }
+        println!("\n{} nodes in blast radius of {}", result.count, node_id);
+    }
+    Ok(())
+}
+
+fn run_callers(db: Option<&PathBuf>, node_id: &str, depth: u32, json: bool) -> Result<()> {
+    let db_path = resolve_db_path(db)?;
+    if !db_path.exists() {
+        anyhow::bail!(
+            "Graph database not found at {}. Run 'ferrograph index --output {}' first.",
+            db_path.display(),
+            db_path.display()
+        );
+    }
+    let store = crate::graph::Store::new_persistent(&db_path)
+        .with_context(|| format!("Failed to open graph at {}", db_path.display()))?;
+    let result = crate::ops::callers(&store, node_id, depth)?;
+    if json {
+        println!("{}", serde_json::to_string_pretty(&result)?);
+    } else {
+        for node in &result.callers {
+            let payload = node.payload.as_deref().unwrap_or("—");
+            println!("{}\t{}\t{payload}", node.id, node.node_type);
+        }
+        println!("\n{} callers of {}", result.count, node_id);
+    }
+    Ok(())
+}
+
+fn run_info(db: Option<&PathBuf>, node_id: &str, json: bool) -> Result<()> {
+    let db_path = resolve_db_path(db)?;
+    if !db_path.exists() {
+        anyhow::bail!(
+            "Graph database not found at {}. Run 'ferrograph index --output {}' first.",
+            db_path.display(),
+            db_path.display()
+        );
+    }
+    let store = crate::graph::Store::new_persistent(&db_path)
+        .with_context(|| format!("Failed to open graph at {}", db_path.display()))?;
+    let info = crate::ops::node_info(&store, node_id)?;
+    match info {
+        Some(n) => {
+            if json {
+                println!("{}", serde_json::to_string_pretty(&n)?);
+            } else {
+                let payload = n.payload.as_deref().unwrap_or("—");
+                println!("{}\t{}\t{payload}", n.id, n.node_type);
+                if !n.outgoing_edges.is_empty() {
+                    println!("\n  Outgoing edges:");
+                    for e in &n.outgoing_edges {
+                        let p = e.payload.as_deref().unwrap_or("—");
+                        println!("    --[{}]--> {}\t{}\t{p}", e.edge_type, e.id, e.node_type);
+                    }
+                }
+                if !n.incoming_edges.is_empty() {
+                    println!("\n  Incoming edges:");
+                    for e in &n.incoming_edges {
+                        let p = e.payload.as_deref().unwrap_or("—");
+                        println!("    <--[{}]-- {}\t{}\t{p}", e.edge_type, e.id, e.node_type);
+                    }
+                }
+            }
+        }
+        None => {
+            if json {
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&serde_json::json!({
+                        "error": "Node not found",
+                        "node_id": node_id
+                    }))?
+                );
+            } else {
+                println!("Node not found: {node_id}");
+            }
+        }
+    }
+    Ok(())
+}
+
+fn run_modules(db: Option<&PathBuf>, root: Option<&str>, json: bool) -> Result<()> {
+    let db_path = resolve_db_path(db)?;
+    if !db_path.exists() {
+        anyhow::bail!(
+            "Graph database not found at {}. Run 'ferrograph index --output {}' first.",
+            db_path.display(),
+            db_path.display()
+        );
+    }
+    let store = crate::graph::Store::new_persistent(&db_path)
+        .with_context(|| format!("Failed to open graph at {}", db_path.display()))?;
+    let result = crate::ops::module_graph(&store, root)?;
+    if json {
+        println!("{}", serde_json::to_string_pretty(&result)?);
+    } else {
+        for edge in &result.edges {
+            println!(
+                "{} ({}) --> {} ({})",
+                edge.from_id, edge.from_type, edge.to_id, edge.to_type
+            );
+        }
+        println!("\n{} containment edges", result.count);
+    }
+    Ok(())
+}
+
+fn run_traits(db: Option<&PathBuf>, trait_name: &str, json: bool) -> Result<()> {
+    let db_path = resolve_db_path(db)?;
+    if !db_path.exists() {
+        anyhow::bail!(
+            "Graph database not found at {}. Run 'ferrograph index --output {}' first.",
+            db_path.display(),
+            db_path.display()
+        );
+    }
+    let store = crate::graph::Store::new_persistent(&db_path)
+        .with_context(|| format!("Failed to open graph at {}", db_path.display()))?;
+    let result = crate::ops::trait_implementors(&store, trait_name)?;
+    if json {
+        println!("{}", serde_json::to_string_pretty(&result)?);
+    } else {
+        for node in &result.implementors {
+            let payload = node.payload.as_deref().unwrap_or("—");
+            println!("{}\t{}\t{payload}", node.id, node.node_type);
+        }
+        println!("\n{} implementors of \"{}\"", result.count, trait_name);
+    }
+    Ok(())
+}
+
+fn run_status(path: &Path, json: bool) -> Result<()> {
     let db_path = if path.is_dir() {
         path.join(".ferrograph")
     } else {
@@ -196,10 +437,24 @@ fn run_status(path: &Path) -> Result<()> {
     }
     let store = crate::graph::Store::new_persistent(&db_path)
         .with_context(|| format!("Failed to open graph at {}", db_path.display()))?;
-    let node_count = store.node_count()?;
-    let edge_count = store.edge_count()?;
-    println!("Graph: {}", db_path.display());
-    println!("  nodes: {node_count}");
-    println!("  edges: {edge_count}");
+    let result = crate::ops::status(&store, &db_path)?;
+    if json {
+        println!("{}", serde_json::to_string_pretty(&result)?);
+    } else {
+        println!("Graph: {}", result.db_path);
+        if let Some(ts) = result.indexed_at {
+            println!("  indexed_at: {ts}");
+        }
+        println!();
+        println!("  Nodes ({} total):", result.node_count);
+        for (type_name, count) in &result.nodes_by_type {
+            println!("    {type_name:<20} {count:>6}");
+        }
+        println!();
+        println!("  Edges ({} total):", result.edge_count);
+        for (type_name, count) in &result.edges_by_type {
+            println!("    {type_name:<20} {count:>6}");
+        }
+    }
     Ok(())
 }

--- a/src/graph/query.rs
+++ b/src/graph/query.rs
@@ -64,6 +64,55 @@ fn extract_node_triple(row: &[DataValue]) -> NodeTriple {
 pub struct Query;
 
 impl Query {
+    /// Count nodes grouped by type. Returns `(type_name, count)` pairs sorted by type name.
+    ///
+    /// # Errors
+    /// Fails if the store query fails.
+    pub fn count_nodes_by_type(store: &Store) -> Result<Vec<(String, usize)>> {
+        let rows = store.run_query("?[type, count(id)] := *nodes[id, type, _]", BTreeMap::new())?;
+        let mut counts: Vec<(String, usize)> = rows
+            .rows
+            .iter()
+            .map(|row| {
+                let type_name = row.first().map(unquote_datavalue).unwrap_or_default();
+                let count = row
+                    .get(1)
+                    .and_then(DataValue::get_int)
+                    .and_then(|n| usize::try_from(n).ok())
+                    .unwrap_or(0);
+                (type_name, count)
+            })
+            .collect();
+        counts.sort_by(|a, b| a.0.cmp(&b.0));
+        Ok(counts)
+    }
+
+    /// Count edges grouped by type. Returns `(type_name, count)` pairs sorted by type name.
+    ///
+    /// # Errors
+    /// Fails if the store query fails.
+    pub fn count_edges_by_type(store: &Store) -> Result<Vec<(String, usize)>> {
+        let rows = store.run_query(
+            "?[edge_type, count(from_id)] := *edges[from_id, _, edge_type]",
+            BTreeMap::new(),
+        )?;
+        let mut counts: Vec<(String, usize)> = rows
+            .rows
+            .iter()
+            .map(|row| {
+                let type_name = row.first().map(unquote_datavalue).unwrap_or_default();
+                let count = row
+                    .get(1)
+                    .and_then(DataValue::get_int)
+                    .and_then(|n| usize::try_from(n).ok())
+                    .unwrap_or(0);
+                (type_name, count)
+            })
+            .collect();
+        counts.sort_by(|a, b| a.0.cmp(&b.0));
+        Ok(counts)
+    }
+
     /// Return all nodes.
     ///
     /// # Errors
@@ -84,6 +133,45 @@ impl Query {
             "?[from_id, to_id, edge_type] := *edges[from_id, to_id, edge_type]",
             BTreeMap::new(),
         )
+    }
+
+    /// Return dead function node ids with payloads from the stored relation.
+    ///
+    /// # Errors
+    /// Fails if the store query fails.
+    pub fn stored_dead_functions_with_payload(store: &Store) -> Result<Vec<NodeTriple>> {
+        let rows = store.run_query(
+            "?[id, type, payload] := *dead_functions[id], *nodes[id, type, payload]",
+            BTreeMap::new(),
+        )?;
+        Ok(rows
+            .rows
+            .iter()
+            .map(|row| extract_node_triple(row))
+            .collect())
+    }
+
+    /// Compute dead functions with payloads (join with nodes table).
+    ///
+    /// # Errors
+    /// Fails if the store query fails.
+    pub fn compute_dead_functions_with_payload(store: &Store) -> Result<Vec<NodeTriple>> {
+        let ids = Self::compute_dead_functions(store)?;
+        if ids.is_empty() {
+            return Ok(Vec::new());
+        }
+        let id_list: Vec<DataValue> = ids.into_iter().map(DataValue::from).collect();
+        let mut params = BTreeMap::new();
+        params.insert("ids".to_string(), DataValue::List(id_list));
+        let rows = store.run_query(
+            "?[id, type, payload] := *nodes[id, type, payload], id in $ids",
+            params,
+        )?;
+        Ok(rows
+            .rows
+            .iter()
+            .map(|row| extract_node_triple(row))
+            .collect())
     }
 
     /// Return dead function node ids from the stored relation (populated by the pipeline).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@
 pub mod config;
 pub mod graph;
 pub mod mcp;
+pub mod ops;
 pub mod pipeline;
 pub mod search;
 pub mod watch;

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -1,0 +1,297 @@
+//! Shared operations used by both the CLI and MCP server.
+
+use std::path::Path;
+
+use anyhow::Result;
+use serde::Serialize;
+
+use crate::graph::query::{ModuleEdge, NodeInfo, Query};
+use crate::graph::Store;
+
+/// Result of a status query.
+#[derive(Debug, Serialize)]
+pub struct StatusResult {
+    pub db_path: String,
+    pub node_count: usize,
+    pub edge_count: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub indexed_at: Option<u64>,
+    pub nodes_by_type: Vec<(String, usize)>,
+    pub edges_by_type: Vec<(String, usize)>,
+}
+
+/// A single search result row.
+#[derive(Debug, Serialize)]
+pub struct SearchResultItem {
+    pub id: String,
+    #[serde(rename = "type")]
+    pub node_type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub payload: Option<String>,
+}
+
+/// Result of a search query.
+#[derive(Debug, Serialize)]
+pub struct SearchResult {
+    pub results: Vec<SearchResultItem>,
+    pub count: usize,
+    pub total: usize,
+}
+
+/// Result of a raw Datalog query.
+#[derive(Debug, Serialize)]
+pub struct QueryResult {
+    pub headers: Vec<String>,
+    pub rows: Vec<Vec<String>>,
+    pub count: usize,
+}
+
+/// Return graph status information including per-type breakdowns.
+///
+/// # Errors
+/// Returns an error if the store query fails.
+pub fn status(store: &Store, store_path: &Path) -> Result<StatusResult> {
+    let node_count = store.node_count()?;
+    let edge_count = store.edge_count()?;
+    let indexed_at = std::fs::metadata(store_path)
+        .ok()
+        .and_then(|m| m.modified().ok())
+        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+        .map(|d| d.as_secs());
+    let nodes_by_type = Query::count_nodes_by_type(store)?;
+    let edges_by_type = Query::count_edges_by_type(store)?;
+    Ok(StatusResult {
+        db_path: store_path.display().to_string(),
+        node_count,
+        edge_count,
+        indexed_at,
+        nodes_by_type,
+        edges_by_type,
+    })
+}
+
+/// Run a text search.
+///
+/// # Errors
+/// Returns an error if the store query fails.
+pub fn search(
+    store: &Store,
+    query: &str,
+    case_insensitive: bool,
+    limit: usize,
+    offset: usize,
+) -> Result<SearchResult> {
+    let (rows, total) = crate::search::text_search(store, query, case_insensitive, limit, offset)?;
+    let results: Vec<SearchResultItem> = rows
+        .into_iter()
+        .map(|(id, node_type, payload)| SearchResultItem {
+            id,
+            node_type,
+            payload,
+        })
+        .collect();
+    let count = results.len();
+    Ok(SearchResult {
+        results,
+        count,
+        total,
+    })
+}
+
+/// A node summary (id, type, payload) used across multiple results.
+#[derive(Debug, Serialize)]
+pub struct NodeSummary {
+    pub id: String,
+    #[serde(rename = "type")]
+    pub node_type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub payload: Option<String>,
+}
+
+/// Result of a dead code analysis.
+#[derive(Debug, Serialize)]
+pub struct DeadCodeResult {
+    pub dead_nodes: Vec<NodeSummary>,
+    pub count: usize,
+    pub source: String,
+    pub caveat: &'static str,
+}
+
+/// Caveat about dynamic dispatch included in dead code results.
+pub const DEAD_CODE_CAVEAT: &str =
+    "Note: functions called via dyn Trait (dynamic dispatch) may appear as dead \
+     because ferrograph uses static analysis only.";
+
+/// Result of a blast radius query.
+#[derive(Debug, Serialize)]
+pub struct BlastRadiusResult {
+    pub from_node_id: String,
+    pub reachable_nodes: Vec<NodeSummary>,
+    pub count: usize,
+}
+
+/// Result of a callers query.
+#[derive(Debug, Serialize)]
+pub struct CallersResult {
+    pub node_id: String,
+    pub callers: Vec<NodeSummary>,
+    pub count: usize,
+}
+
+/// Result of a trait implementors query.
+#[derive(Debug, Serialize)]
+pub struct TraitImplementorsResult {
+    pub trait_name: String,
+    pub implementors: Vec<NodeSummary>,
+    pub count: usize,
+}
+
+/// Result of a module graph query.
+#[derive(Debug, Serialize)]
+pub struct ModuleGraphResult {
+    pub edges: Vec<ModuleEdge>,
+    pub count: usize,
+}
+
+/// Find dead (unreachable) code with symbol names.
+///
+/// # Errors
+/// Returns an error if the store query or glob pattern is invalid.
+pub fn dead_code(store: &Store, file_glob: Option<&str>) -> Result<DeadCodeResult> {
+    let mut triples = Query::stored_dead_functions_with_payload(store)?;
+    let source = if triples.is_empty() {
+        triples = Query::compute_dead_functions_with_payload(store)?;
+        "computed"
+    } else {
+        "stored"
+    };
+    if let Some(pattern) = file_glob {
+        let pat = glob::Pattern::new(pattern)?;
+        triples.retain(|(id, _, _)| pat.matches(id));
+    }
+    let dead_nodes: Vec<NodeSummary> = triples
+        .into_iter()
+        .map(|(id, node_type, payload)| NodeSummary {
+            id,
+            node_type,
+            payload,
+        })
+        .collect();
+    let count = dead_nodes.len();
+    Ok(DeadCodeResult {
+        dead_nodes,
+        count,
+        source: source.to_string(),
+        caveat: DEAD_CODE_CAVEAT,
+    })
+}
+
+/// Compute the blast radius from a given node.
+///
+/// # Errors
+/// Returns an error if the store query fails.
+pub fn blast_radius(store: &Store, node_id: &str) -> Result<BlastRadiusResult> {
+    let nodes = Query::blast_radius(store, node_id)?;
+    let reachable_nodes: Vec<NodeSummary> = nodes
+        .into_iter()
+        .map(|(id, node_type, payload)| NodeSummary {
+            id,
+            node_type,
+            payload,
+        })
+        .collect();
+    let count = reachable_nodes.len();
+    Ok(BlastRadiusResult {
+        from_node_id: node_id.to_string(),
+        reachable_nodes,
+        count,
+    })
+}
+
+/// Find callers of a node up to a given depth.
+///
+/// # Errors
+/// Returns an error if the store query fails.
+pub fn callers(store: &Store, node_id: &str, depth: u32) -> Result<CallersResult> {
+    let nodes = Query::callers(store, node_id, depth)?;
+    let callers: Vec<NodeSummary> = nodes
+        .into_iter()
+        .map(|(id, node_type, payload)| NodeSummary {
+            id,
+            node_type,
+            payload,
+        })
+        .collect();
+    let count = callers.len();
+    Ok(CallersResult {
+        node_id: node_id.to_string(),
+        callers,
+        count,
+    })
+}
+
+/// Get full info for a node.
+///
+/// # Errors
+/// Returns an error if the store query fails.
+pub fn node_info(store: &Store, node_id: &str) -> Result<Option<NodeInfo>> {
+    Query::node_info(store, node_id)
+}
+
+/// Find implementors of a trait.
+///
+/// # Errors
+/// Returns an error if the store query fails.
+pub fn trait_implementors(store: &Store, trait_name: &str) -> Result<TraitImplementorsResult> {
+    let nodes = Query::trait_implementors(store, trait_name).unwrap_or_default();
+    let implementors: Vec<NodeSummary> = nodes
+        .into_iter()
+        .map(|(id, node_type, payload)| NodeSummary {
+            id,
+            node_type,
+            payload,
+        })
+        .collect();
+    let count = implementors.len();
+    Ok(TraitImplementorsResult {
+        trait_name: trait_name.to_string(),
+        implementors,
+        count,
+    })
+}
+
+/// Get the module containment graph.
+///
+/// # Errors
+/// Returns an error if the store query fails.
+pub fn module_graph(store: &Store, root: Option<&str>) -> Result<ModuleGraphResult> {
+    let edges = Query::module_graph(store, root)?;
+    let count = edges.len();
+    Ok(ModuleGraphResult { edges, count })
+}
+
+/// Run a raw Datalog query.
+///
+/// # Errors
+/// Returns an error if the store query fails.
+pub fn query(store: &Store, script: &str) -> Result<QueryResult> {
+    let params = std::collections::BTreeMap::new();
+    let script = if script.contains(":limit") {
+        script.trim().to_string()
+    } else {
+        format!("{}\n:limit 10000", script.trim())
+    };
+    let named_rows = store.run_query(&script, params)?;
+    let headers = named_rows.headers.clone();
+    let rows: Vec<Vec<String>> = named_rows
+        .rows
+        .iter()
+        .map(|row| row.iter().map(std::string::ToString::to_string).collect())
+        .collect();
+    let count = rows.len();
+    Ok(QueryResult {
+        headers,
+        rows,
+        count,
+    })
+}

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -42,7 +42,7 @@ pub struct SearchResult {
 #[derive(Debug, Serialize)]
 pub struct QueryResult {
     pub headers: Vec<String>,
-    pub rows: Vec<Vec<String>>,
+    pub rows: Vec<Vec<serde_json::Value>>,
     pub count: usize,
 }
 
@@ -243,7 +243,7 @@ pub fn node_info(store: &Store, node_id: &str) -> Result<Option<NodeInfo>> {
 /// # Errors
 /// Returns an error if the store query fails.
 pub fn trait_implementors(store: &Store, trait_name: &str) -> Result<TraitImplementorsResult> {
-    let nodes = Query::trait_implementors(store, trait_name).unwrap_or_default();
+    let nodes = Query::trait_implementors(store, trait_name)?;
     let implementors: Vec<NodeSummary> = nodes
         .into_iter()
         .map(|(id, node_type, payload)| NodeSummary {
@@ -283,10 +283,10 @@ pub fn query(store: &Store, script: &str) -> Result<QueryResult> {
     };
     let named_rows = store.run_query(&script, params)?;
     let headers = named_rows.headers.clone();
-    let rows: Vec<Vec<String>> = named_rows
+    let rows: Vec<Vec<serde_json::Value>> = named_rows
         .rows
         .iter()
-        .map(|row| row.iter().map(std::string::ToString::to_string).collect())
+        .map(|row| row.iter().map(crate::graph::datavalue_to_json).collect())
         .collect();
     let count = rows.len();
     Ok(QueryResult {

--- a/tests/integration_cli.rs
+++ b/tests/integration_cli.rs
@@ -13,15 +13,16 @@ fn fixture_path(name: &str) -> std::path::PathBuf {
         .join(name)
 }
 
-/// Parse node count from `status` stdout (line containing "nodes: N").
+/// Parse node count from `status` stdout (line containing "Nodes (N total)").
 fn parse_node_count(stdout: &str) -> u32 {
     stdout
         .lines()
-        .find(|l| l.contains("nodes:"))
+        .find(|l| l.contains("Nodes ("))
         .and_then(|l| {
-            l.split(':')
-                .nth(1)
-                .and_then(|s| s.trim().parse::<u32>().ok())
+            // Extract number from "  Nodes (42 total):"
+            let start = l.find('(')? + 1;
+            let end = l.find(" total")?;
+            l[start..end].trim().parse::<u32>().ok()
         })
         .expect("failed to parse node count from status output")
 }
@@ -82,11 +83,11 @@ fn cli_index_and_status_and_query() {
     );
     let stdout = String::from_utf8_lossy(&out.stdout);
     assert!(
-        stdout.contains("nodes:"),
+        stdout.contains("Nodes ("),
         "status should report nodes: {stdout}"
     );
     assert!(
-        stdout.contains("edges:"),
+        stdout.contains("Edges ("),
         "status should report edges: {stdout}"
     );
     let node_count = parse_node_count(&stdout);

--- a/tests/integration_cli.rs
+++ b/tests/integration_cli.rs
@@ -204,6 +204,332 @@ fn cli_persistent_reopen() {
     assert!(count1 > 0, "expected nodes after index");
 }
 
+/// Index the `single_crate` fixture into a temp DB and return `(db_path, tempdir)`.
+/// The tempdir is returned so the caller keeps it alive for the test's duration.
+fn index_fixture() -> (std::path::PathBuf, tempfile::TempDir) {
+    let fixture = fixture_path("single_crate");
+    assert!(fixture.exists(), "fixture missing: {}", fixture.display());
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join(".ferrograph");
+    let out = ferrograph_cmd()
+        .args([
+            "index",
+            "--output",
+            db_path.to_str().unwrap(),
+            fixture.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "index failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    (db_path, dir)
+}
+
+#[test]
+fn cli_dead() {
+    let (db_path, _dir) = index_fixture();
+    let out = ferrograph_cmd()
+        .args(["dead", "--db", db_path.to_str().unwrap()])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "dead failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("private_unused"),
+        "dead should include private_unused: {stdout}"
+    );
+    assert!(
+        stdout.contains("dead nodes found"),
+        "dead should print summary line: {stdout}"
+    );
+    assert!(
+        stdout.contains("dynamic dispatch"),
+        "dead should print dynamic dispatch caveat: {stdout}"
+    );
+}
+
+#[test]
+fn cli_dead_json() {
+    let (db_path, _dir) = index_fixture();
+    let out = ferrograph_cmd()
+        .args(["--json", "dead", "--db", db_path.to_str().unwrap()])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "dead --json failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let parsed: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("dead --json output is not valid JSON: {e}\n{stdout}"));
+    assert!(
+        parsed["count"].as_u64().unwrap_or(0) > 0,
+        "dead --json should report count > 0: {stdout}"
+    );
+    assert!(
+        parsed["dead_nodes"].is_array(),
+        "dead --json should have dead_nodes array: {stdout}"
+    );
+    assert!(
+        parsed["caveat"].is_string(),
+        "dead --json should include caveat: {stdout}"
+    );
+}
+
+#[test]
+fn cli_blast() {
+    let (db_path, _dir) = index_fixture();
+    // use_add calls utils::add, so blast radius from use_add should include something
+    let out = ferrograph_cmd()
+        .args(["search", "--db", db_path.to_str().unwrap(), "pub::use_add"])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let node_id = stdout.lines().next().unwrap().split('\t').next().unwrap();
+
+    let out = ferrograph_cmd()
+        .args(["blast", "--db", db_path.to_str().unwrap(), node_id])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "blast failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("blast radius"),
+        "blast should print summary: {stdout}"
+    );
+}
+
+#[test]
+fn cli_info() {
+    let (db_path, _dir) = index_fixture();
+    // Search for greet function to get a node ID
+    let out = ferrograph_cmd()
+        .args(["search", "--db", db_path.to_str().unwrap(), "pub::greet"])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let node_id = stdout.lines().next().unwrap().split('\t').next().unwrap();
+
+    let out = ferrograph_cmd()
+        .args(["info", "--db", db_path.to_str().unwrap(), node_id])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "info failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("greet"),
+        "info should show node payload: {stdout}"
+    );
+}
+
+#[test]
+fn cli_info_not_found() {
+    let (db_path, _dir) = index_fixture();
+    let out = ferrograph_cmd()
+        .args(["info", "--db", db_path.to_str().unwrap(), "nonexistent#0:0"])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("not found"),
+        "info for missing node should say not found: {stdout}"
+    );
+}
+
+#[test]
+fn cli_modules() {
+    let (db_path, _dir) = index_fixture();
+    let out = ferrograph_cmd()
+        .args(["modules", "--db", db_path.to_str().unwrap()])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "modules failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("containment edges"),
+        "modules should print summary: {stdout}"
+    );
+}
+
+#[test]
+fn cli_traits() {
+    let (db_path, _dir) = index_fixture();
+    let out = ferrograph_cmd()
+        .args(["traits", "--db", db_path.to_str().unwrap(), "Draw"])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "traits failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("implementors of"),
+        "traits should print summary: {stdout}"
+    );
+}
+
+#[test]
+fn cli_callers() {
+    let (db_path, _dir) = index_fixture();
+    // Find the add function (called by use_add)
+    let out = ferrograph_cmd()
+        .args(["search", "--db", db_path.to_str().unwrap(), "pub::add"])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let node_id = stdout.lines().next().unwrap().split('\t').next().unwrap();
+
+    let out = ferrograph_cmd()
+        .args(["callers", "--db", db_path.to_str().unwrap(), node_id])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "callers failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("callers of"),
+        "callers should print summary: {stdout}"
+    );
+}
+
+#[test]
+fn cli_status_json() {
+    let (db_path, _dir) = index_fixture();
+    let out = ferrograph_cmd()
+        .args([
+            "--json",
+            "status",
+            db_path.parent().unwrap().to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "status --json failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let parsed: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("status --json output is not valid JSON: {e}\n{stdout}"));
+    assert!(
+        parsed["node_count"].as_u64().unwrap_or(0) > 0,
+        "status --json should report node_count > 0: {stdout}"
+    );
+    assert!(
+        parsed["nodes_by_type"].is_array(),
+        "status --json should have nodes_by_type: {stdout}"
+    );
+    assert!(
+        parsed["edges_by_type"].is_array(),
+        "status --json should have edges_by_type: {stdout}"
+    );
+}
+
+#[test]
+fn cli_query_json() {
+    let (db_path, _dir) = index_fixture();
+    let out = ferrograph_cmd()
+        .args([
+            "--json",
+            "query",
+            "--db",
+            db_path.to_str().unwrap(),
+            "?[n] := n in [1, 2, 3]",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "query --json failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let parsed: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("query --json output is not valid JSON: {e}\n{stdout}"));
+    let rows = parsed["rows"].as_array().expect("rows should be array");
+    assert_eq!(rows.len(), 3, "should have 3 rows");
+    // Values should be numeric, not stringified
+    assert!(
+        rows[0][0].is_number(),
+        "query --json should preserve numeric types, got: {}",
+        rows[0][0]
+    );
+}
+
+#[test]
+fn cli_search_json() {
+    let (db_path, _dir) = index_fixture();
+    let out = ferrograph_cmd()
+        .args([
+            "--json",
+            "search",
+            "--db",
+            db_path.to_str().unwrap(),
+            "greet",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "search --json failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let parsed: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("search --json output is not valid JSON: {e}\n{stdout}"));
+    assert!(
+        parsed["count"].as_u64().unwrap_or(0) > 0,
+        "search --json should find results: {stdout}"
+    );
+    assert!(
+        parsed["results"].is_array(),
+        "search --json should have results array: {stdout}"
+    );
+}
+
+#[test]
+fn cli_help_lists_new_subcommands() {
+    let out = ferrograph_cmd().arg("--help").output().unwrap();
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    for sub in ["dead", "blast", "callers", "info", "modules", "traits"] {
+        assert!(
+            stdout.contains(sub),
+            "help should list new subcommand '{sub}', got: {stdout}"
+        );
+    }
+    assert!(
+        stdout.contains("--json"),
+        "help should list --json flag: {stdout}"
+    );
+}
+
 #[test]
 fn cli_index_nonexistent_path_fails() {
     let out = ferrograph_cmd()


### PR DESCRIPTION
## Summary

- **#41**: Add 6 new CLI subcommands (`dead`, `blast`, `callers`, `info`, `modules`, `traits`) wrapping the same query logic the MCP server already exposes
- **#42**: `ferrograph status` now shows per-type node/edge breakdowns instead of just totals
- **#43**: Global `--json` flag for structured output on all subcommands
- **#44**: Dead code output includes symbol names (not just node IDs) and a dynamic dispatch caveat footer
- **Bonus**: `ferrograph --version` now includes the version number in the ASCII banner

### Architecture

New `src/ops.rs` shared operations layer sits between the graph queries and both CLI/MCP consumers. Each function takes `&Store` + plain parameters and returns a serializable result struct, enabling `--json` with zero per-type formatting code.

Closes #41, closes #42, closes #43, closes #44

## Test plan

- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo test` — all 30+ tests pass (unit + integration)
- [x] `cargo fmt --check` — clean
- [x] Manual: `ferrograph --version` shows `v1.3.0`
- [x] Manual: `ferrograph status` shows per-type breakdowns
- [x] Manual: `ferrograph --json status` returns valid JSON
- [x] Manual: `ferrograph dead` shows symbol names + caveat
- [x] Manual: all 6 new subcommands appear in `--help`

🤖 Generated with [Claude Code](https://claude.com/claude-code)