### PR TITLE
docs: Claude Code skill installer and README

### DIFF
--- a/.claude/skills/ferrograph/SKILL.md
+++ b/.claude/skills/ferrograph/SKILL.md
@@ -1,0 +1,313 @@
+# /ferrograph
+
+Graph-powered Rust code intelligence. Indexes Rust codebases into a queryable knowledge graph via tree-sitter AST extraction, then exposes CLI and MCP interfaces for search, impact analysis, dead code detection, and raw Datalog queries.
+
+## Usage
+
+```
+/ferrograph                              # full pipeline on current directory
+/ferrograph <path>                       # full pipeline on a specific Rust project
+/ferrograph search "<term>"              # text search over indexed symbols
+/ferrograph dead                         # list dead (unreachable) code
+/ferrograph dead --file "src/**"         # dead code filtered by file glob
+/ferrograph blast "<node_id>"            # impact analysis: what breaks if this changes?
+/ferrograph callers "<node_id>"          # reverse call graph (who calls this?)
+/ferrograph callers "<node_id>" --depth 3  # transitive callers up to N hops
+/ferrograph info "<node_id>"             # full detail on a single node (edges in/out)
+/ferrograph modules                      # module containment tree
+/ferrograph modules --root "./src/"      # module tree filtered by path prefix
+/ferrograph traits "<name>"              # find all implementors of a trait
+/ferrograph query "<datalog>"            # raw CozoDB Datalog query
+/ferrograph watch                        # watch for file changes, auto-reindex
+```
+
+Add `--json` to any subcommand for machine-readable output.
+
+## What ferrograph is for
+
+ferrograph builds a persistent knowledge graph from Rust source code using tree-sitter parsing. No LLM tokens are consumed — extraction is entirely deterministic.
+
+Three things it does that reading code cannot:
+1. **Cross-file call graph** — traces function calls across module boundaries, through imports and re-exports, including calls inside macro invocations
+2. **Impact analysis** — `blast` shows every node transitively reachable from a change point, answering "what breaks if I touch this?"
+3. **Dead code detection** — finds functions unreachable from any entry point (`main`, `pub`, `#[test]`, `#[bench]`)
+
+The graph persists in a `.ferrograph` CozoDB database (SQLite-backed). Once indexed, queries are instant. Use `watch` mode to keep the index fresh during development.
+
+## Node ID format
+
+All node IDs are relative paths with line:column anchors:
+```
+./src/main.rs#42:1        — function at line 42, column 1
+./src/lib.rs#10:5         — item at line 10, column 5
+```
+
+Use `search` to find node IDs by name rather than constructing them manually.
+
+## What You Must Do When Invoked
+
+If no path is given, use `.` (current directory). Do not ask the user for a path.
+
+### Step 1 — Check installation
+
+```bash
+which ferrograph >/dev/null 2>&1 || { echo "ERROR: ferrograph not found. Install with: cargo install ferrograph"; exit 1; }
+ferrograph --version
+```
+
+If not installed, tell the user and stop. Do not attempt to install it.
+
+### Step 2 — Detect Rust project
+
+```bash
+if [ -f "INPUT_PATH/Cargo.toml" ]; then
+    echo "Rust project found: INPUT_PATH"
+else
+    echo "ERROR: No Cargo.toml found at INPUT_PATH"
+    exit 1
+fi
+```
+
+Replace `INPUT_PATH`. If no Rust project is found, stop and tell the user.
+
+### Step 3 — Index
+
+Check whether a fresh index already exists before re-indexing:
+
+```bash
+DB_PATH="INPUT_PATH/.ferrograph"
+if [ -f "$DB_PATH" ]; then
+    NEWEST_RS=$(find INPUT_PATH -name '*.rs' -newer "$DB_PATH" 2>/dev/null | head -1)
+    if [ -n "$NEWEST_RS" ]; then
+        echo "Index is stale — re-indexing..."
+        ferrograph index INPUT_PATH -o "$DB_PATH" 2>&1
+    else
+        echo "Index is up to date — skipping reindex"
+    fi
+else
+    ferrograph index INPUT_PATH -o "$DB_PATH" 2>&1
+fi
+```
+
+Note any warnings from the indexer (ambiguous calls, duplicate names) — mention them in the report but don't treat them as errors.
+
+### Step 4 — Explore the graph
+
+Run these **in parallel**:
+
+```bash
+# Overview with node/edge type breakdown
+ferrograph status INPUT_PATH
+
+# Dead code (includes symbol names)
+ferrograph dead -d "$DB_PATH"
+
+# All traits and their implementors
+ferrograph traits "" -d "$DB_PATH" 2>&1 || ferrograph query '?[id, payload] := *nodes[id, "trait", payload]' -d "$DB_PATH"
+
+# Unsafe usage
+ferrograph query '?[from, to] := *edges[from, to, "uses_unsafe"]' -d "$DB_PATH"
+```
+
+### Step 5 — Report findings
+
+```
+## Ferrograph Report: PROJECT_NAME
+
+**Graph**: N nodes, M edges (from status breakdown)
+
+### Key Traits
+- TraitName (file.rs#line) — N implementors
+
+### Dead Code (N items)
+- function_name (file.rs#line)
+- ...
+(Note: functions called via dyn Trait may appear dead — see caveat below)
+
+### Unsafe Usage
+- N unsafe blocks/functions
+
+### Suggested Explorations
+(2-3 interesting findings: high-degree nodes, surprising dead code, complex call chains)
+```
+
+After the report, offer to dig deeper:
+> "Want me to trace the call graph for any of these, or check the blast radius of a specific function?"
+
+---
+
+## Subcommands
+
+### /ferrograph search "\<term\>"
+
+```bash
+DB_PATH=$(find . -name '.ferrograph' -maxdepth 3 | head -1)
+ferrograph search "TERM" -d "$DB_PATH"
+```
+
+Add `-c` for case-insensitive. Use this to find node IDs before running `blast`, `callers`, or `info`.
+
+### /ferrograph dead
+
+```bash
+ferrograph dead -d "$DB_PATH"
+# Filter by file:
+ferrograph dead -d "$DB_PATH" --file "./src/validate/**"
+```
+
+Output includes node ID, type, and symbol name. Always mention the dynamic dispatch caveat.
+
+### /ferrograph blast "\<node_id\>"
+
+```bash
+ferrograph blast NODE_ID -d "$DB_PATH"
+```
+
+If user gives a name not an ID, run `search` first to find the ID.
+
+### /ferrograph callers "\<node_id\>"
+
+```bash
+ferrograph callers NODE_ID -d "$DB_PATH"
+ferrograph callers NODE_ID -d "$DB_PATH" --depth 3   # transitive
+```
+
+### /ferrograph info "\<node_id\>"
+
+```bash
+ferrograph info NODE_ID -d "$DB_PATH"
+```
+
+Shows type, payload, and all incoming/outgoing edges.
+
+### /ferrograph modules
+
+```bash
+ferrograph modules -d "$DB_PATH"
+ferrograph modules -d "$DB_PATH" --root "./src/"
+```
+
+### /ferrograph traits "\<name\>"
+
+```bash
+ferrograph traits "ValidationRule" -d "$DB_PATH"
+```
+
+Substring match — pass an empty string to list all traits (may not be supported; fall back to Datalog if it errors).
+
+### /ferrograph query "\<datalog\>"
+
+```bash
+ferrograph query 'DATALOG' -d "$DB_PATH"
+```
+
+See Datalog Cookbook below. If the query fails, check:
+- Missing `*` prefix (use `*nodes`, not `nodes`)
+- Column order: `*nodes[id, type, payload]`, `*edges[from_id, to_id, edge_type]`
+
+### /ferrograph watch
+
+```bash
+ferrograph watch INPUT_PATH --output INPUT_PATH/.ferrograph
+```
+
+Runs in the foreground — tell the user to run this in a separate terminal.
+
+---
+
+## CozoDB Datalog Cookbook
+
+Three relations underpin everything:
+
+```
+*nodes[id, type, payload]          — all code entities
+*edges[from_id, to_id, edge_type]  — all relationships  
+*dead_functions[id]                — unreachable functions
+```
+
+**Node types**: `file`, `module`, `function`, `struct`, `enum`, `trait`, `impl`, `type_alias`, `const`, `static`, `macro`, `crate_root`, `primitive`, `external_type`
+
+**Edge types**: `contains`, `imports`, `calls`, `references`, `implements_trait`, `owns`, `borrows`, `borrows_mut`, `expands_to`, `uses_unsafe`, `lifetime_scope`, `changes_with`
+
+### Common recipes
+
+**Functions in a specific file:**
+```datalog
+?[id, payload] := *nodes[id, "function", payload], starts_with(id, "./src/lib.rs")
+```
+
+**Dead functions with names (prefer `ferrograph dead` instead):**
+```datalog
+?[id, payload] := *dead_functions[id], *nodes[id, _, payload]
+```
+
+**Who calls a specific function:**
+```datalog
+?[caller, payload] := *edges[caller, "TARGET_NODE_ID", "calls"], *nodes[caller, _, payload]
+```
+
+**What does a function call:**
+```datalog
+?[callee, payload] := *edges["SOURCE_NODE_ID", callee, "calls"], *nodes[callee, _, payload]
+```
+
+**Transitive callers (recursive):**
+```datalog
+reach[x] := *edges[x, "TARGET_NODE_ID", "calls"]
+reach[x] := *edges[x, mid, "calls"], reach[mid]
+?[id, type, payload] := reach[id], *nodes[id, type, payload]
+```
+
+**Trait implementations:**
+```datalog
+?[impl_id, trait_id, trait_name] := *edges[impl_id, trait_id, "implements_trait"], *nodes[trait_id, "trait", trait_name]
+```
+
+**Type references from a module:**
+```datalog
+?[from, to, to_type] := *edges[from, to, "references"], starts_with(from, "./src/validate/"), *nodes[to, to_type, _]
+```
+
+**Unsafe code:**
+```datalog
+?[from, to] := *edges[from, to, "uses_unsafe"]
+```
+
+**Borrow relationships:**
+```datalog
+?[borrower, borrowed, edge_type] := *edges[borrower, borrowed, edge_type], edge_type in ["borrows", "borrows_mut"]
+```
+
+**Items with lifetime parameters:**
+```datalog
+?[id, type, payload] := *edges[id, id, "lifetime_scope"], *nodes[id, type, payload]
+```
+
+**All public functions:**
+```datalog
+?[id, payload] := *nodes[id, "function", payload], starts_with(payload, "pub::")
+```
+
+**All test functions:**
+```datalog
+?[id, payload] := *nodes[id, "function", payload], starts_with(payload, "test::")
+```
+
+---
+
+## Using ferrograph with graphify
+
+For monorepos with both Rust and JS/TS code:
+
+- **ferrograph** handles Rust (AST-based, zero token cost, deep Rust semantics)
+- **graphify** handles JS/TS + docs + images (AST + LLM semantic extraction)
+
+Each tool produces independent output — ferrograph in `.ferrograph`, graphify in `graphify-out/`. Cross-reference findings manually: if ferrograph shows a Rust validation rule calling `load_spec_dimensions`, and graphify shows the spec documents that define those dimensions, you can trace the full chain.
+
+---
+
+## Honesty rules
+
+- ferrograph uses static analysis only. Functions called via `dyn Trait` (dynamic dispatch) may appear as dead code. Always mention this caveat.
+- The `changes_with` edge type requires the `git` feature and may not be populated.
+- Node IDs are positional (line:col). Reindex after significant code changes or IDs may be stale.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,97 @@
+# Ferrograph — Claude Code Rules
+
+## Rust Quality Standards
+
+### Clippy
+
+This project enforces **`clippy::pedantic`** (see `[lints.clippy]` in `Cargo.toml`).
+
+- Run `cargo clippy -- -D warnings` after every meaningful code change. All warnings must be resolved before considering work complete.
+- Treat clippy suggestions as requirements, not optional advice.
+- When clippy offers a cleaner idiom (e.g., `if let` instead of `match` with one arm, `map_or` instead of `match` on `Option`), prefer the idiomatic form.
+- Do not add `#[allow(...)]` attributes unless there is a genuinely unavoidable false positive. If suppression is necessary, leave a comment explaining why.
+
+### Formatting
+
+- Run `cargo fmt` before every commit. Code that does not pass `cargo fmt --check` must not be committed.
+- Do not use `#[rustfmt::skip]` unless there is a strong readability reason with an accompanying comment.
+
+### Pre-commit checklist
+
+Run in order before every commit:
+1. `cargo fmt`
+2. `cargo clippy -- -D warnings`
+3. `cargo test`
+
+All three must pass before creating a commit.
+
+## Commit Messages
+
+All commits must follow [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+<type>[optional scope]: <description>
+```
+
+Common types: `feat`, `fix`, `refactor`, `test`, `docs`, `chore`, `ci`, `perf`.
+
+Examples:
+- `feat(cli): add named subcommands for dead code and blast radius`
+- `fix(parser): handle nested impl blocks`
+- `docs: add Claude Code integration to README`
+
+## Architecture
+
+### CozoDB schema
+
+Three stored relations underpin the graph:
+
+| Relation | Key | Columns |
+|---|---|---|
+| `nodes` | `id` (String) | `type` (String), `payload` (String?) |
+| `edges` | `from_id, to_id, edge_type` (all String) | — |
+| `dead_functions` | `id` (String) | — |
+
+Node IDs are relative to the project root: `./src/main.rs#line:col`
+
+### Pipeline phases
+
+Index runs 12 phases in order: file discovery → AST extraction → primitive nodes → module resolution → call graph → impl→trait edges → type references → owns edges → borrows edges → borrows_mut edges → macro expansion → dead code detection.
+
+Optional: git change-coupling (`changes_with` edges) via `git` feature flag.
+
+### MCP server
+
+10 tools: `reindex`, `status`, `search`, `node_info`, `dead_code`, `blast_radius`, `callers`, `query`, `trait_implementors`, `module_graph`.
+
+The `query` tool is read-only — mutations (`:put`, `:rm`, `:create`, etc.) are blocked at parse time.
+
+## Testing
+
+- Integration tests live in `tests/`
+- Unit tests live alongside source in `src/`
+- Run `cargo test` to execute all tests
+- When adding a new CLI subcommand or MCP tool, add a corresponding integration test
+
+## Using the Claude Code Skill
+
+A Claude Code skill for ferrograph lives at `.claude/skills/ferrograph/SKILL.md`. It covers the full pipeline: indexing, exploring, reporting, all subcommands, and the CozoDB Datalog cookbook.
+
+To install it locally, symlink or copy to your user skill directory:
+
+```bash
+# Symlink (stays in sync with repo updates)
+mkdir -p ~/.claude/skills/ferrograph
+ln -sf "$(pwd)/.claude/skills/ferrograph/SKILL.md" ~/.claude/skills/ferrograph/SKILL.md
+
+# Or copy
+cp .claude/skills/ferrograph/SKILL.md ~/.claude/skills/ferrograph/SKILL.md
+```
+
+Then add to your `~/.claude/CLAUDE.md`:
+
+```markdown
+### ferrograph
+- **ferrograph** (`~/.claude/skills/ferrograph/SKILL.md`) - Rust code intelligence via knowledge graph. Trigger: `/ferrograph`
+When the user types `/ferrograph`, invoke the Skill tool with `skill: "ferrograph"` before doing anything else.
+```

--- a/README.md
+++ b/README.md
@@ -53,24 +53,23 @@ cargo run -- mcp
 
 ### Setup with Claude Code
 
-A Claude Code skill lives at `.claude/skills/ferrograph/SKILL.md` in this repo. It gives Claude a full workflow for indexing, exploring, and querying ferrograph graphs via the `/ferrograph` slash command.
+A Claude Code skill gives Claude a full workflow for indexing, exploring, and querying ferrograph graphs via the `/ferrograph` slash command.
 
-Install it by symlinking to your user skill directory (so it stays in sync with repo updates):
+**Install (any method):**
 
 ```bash
-mkdir -p ~/.claude/skills/ferrograph
-ln -sf "$(pwd)/.claude/skills/ferrograph/SKILL.md" ~/.claude/skills/ferrograph/SKILL.md
+# From GitHub (no clone needed)
+curl -fsSL https://raw.githubusercontent.com/GarthDB/ferrograph/main/install-claude-skill.sh | sh
+
+# From a local clone
+sh install-claude-skill.sh
 ```
 
-Then add to your `~/.claude/CLAUDE.md`:
-
-```markdown
-### ferrograph
-- **ferrograph** (`~/.claude/skills/ferrograph/SKILL.md`) - Rust code intelligence via knowledge graph. Trigger: `/ferrograph`
-When the user types `/ferrograph`, invoke the Skill tool with `skill: "ferrograph"` before doing anything else.
-```
+The script writes the skill to `~/.claude/skills/ferrograph/SKILL.md` and patches `~/.claude/CLAUDE.md` automatically.
 
 Once installed, use `/ferrograph <path>` in any Claude Code session to index and explore a Rust project.
+
+> **Coming soon**: `ferrograph claude install` will handle this in a single command with no script required ([#47](https://github.com/GarthDB/ferrograph/issues/47)).
 
 A `CLAUDE.md` in the repo root covers project-specific rules for working on ferrograph itself (Rust standards, commit format, architecture notes).
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,29 @@ cargo run -- watch . --output .ferrograph
 cargo run -- mcp
 ```
 
+### Setup with Claude Code
+
+A Claude Code skill lives at `.claude/skills/ferrograph/SKILL.md` in this repo. It gives Claude a full workflow for indexing, exploring, and querying ferrograph graphs via the `/ferrograph` slash command.
+
+Install it by symlinking to your user skill directory (so it stays in sync with repo updates):
+
+```bash
+mkdir -p ~/.claude/skills/ferrograph
+ln -sf "$(pwd)/.claude/skills/ferrograph/SKILL.md" ~/.claude/skills/ferrograph/SKILL.md
+```
+
+Then add to your `~/.claude/CLAUDE.md`:
+
+```markdown
+### ferrograph
+- **ferrograph** (`~/.claude/skills/ferrograph/SKILL.md`) - Rust code intelligence via knowledge graph. Trigger: `/ferrograph`
+When the user types `/ferrograph`, invoke the Skill tool with `skill: "ferrograph"` before doing anything else.
+```
+
+Once installed, use `/ferrograph <path>` in any Claude Code session to index and explore a Rust project.
+
+A `CLAUDE.md` in the repo root covers project-specific rules for working on ferrograph itself (Rust standards, commit format, architecture notes).
+
 ### Setup with Cursor
 
 Add to `.cursor/mcp.json` in your project (or global settings):

--- a/install-claude-skill.sh
+++ b/install-claude-skill.sh
@@ -10,10 +10,11 @@ SKILL_DIR="$HOME/.claude/skills/ferrograph"
 CLAUDE_MD="$HOME/.claude/CLAUDE.md"
 REMOTE_SKILL="https://raw.githubusercontent.com/GarthDB/ferrograph/main/.claude/skills/ferrograph/SKILL.md"
 
-# Only resolve a local repo path when NOT piped (stdin is a terminal).
-# When piped (curl | sh), $0 is the shell binary, so dirname would resolve
-# relative to the caller's cwd and could pick up a stale local copy.
-if [ -t 0 ]; then
+# Only resolve a local repo path when $0 points to an actual file (i.e., we
+# were invoked as a script). When piped (curl | sh), $0 is the shell binary
+# (e.g. /bin/sh) or a stdin placeholder, not our script, so dirname would
+# resolve relative to the wrong directory.
+if [ -f "$0" ]; then
   REPO_SKILL="$(cd "$(dirname "$0")" 2>/dev/null && pwd)/.claude/skills/ferrograph/SKILL.md"
 else
   REPO_SKILL=""

--- a/install-claude-skill.sh
+++ b/install-claude-skill.sh
@@ -8,8 +8,16 @@ set -e
 
 SKILL_DIR="$HOME/.claude/skills/ferrograph"
 CLAUDE_MD="$HOME/.claude/CLAUDE.md"
-REPO_SKILL="$(cd "$(dirname "$0")" 2>/dev/null && pwd)/.claude/skills/ferrograph/SKILL.md"
 REMOTE_SKILL="https://raw.githubusercontent.com/GarthDB/ferrograph/main/.claude/skills/ferrograph/SKILL.md"
+
+# Only resolve a local repo path when NOT piped (stdin is a terminal).
+# When piped (curl | sh), $0 is the shell binary, so dirname would resolve
+# relative to the caller's cwd and could pick up a stale local copy.
+if [ -t 0 ]; then
+  REPO_SKILL="$(cd "$(dirname "$0")" 2>/dev/null && pwd)/.claude/skills/ferrograph/SKILL.md"
+else
+  REPO_SKILL=""
+fi
 
 SKILL_ENTRY='### ferrograph
 - **ferrograph** (`~/.claude/skills/ferrograph/SKILL.md`) - Rust code intelligence via knowledge graph. Trigger: `/ferrograph`
@@ -19,7 +27,7 @@ When the user types `/ferrograph`, invoke the Skill tool with `skill: "ferrograp
 
 mkdir -p "$SKILL_DIR"
 
-if [ -f "$REPO_SKILL" ]; then
+if [ -n "$REPO_SKILL" ] && [ -f "$REPO_SKILL" ]; then
   cp "$REPO_SKILL" "$SKILL_DIR/SKILL.md"
   echo "✓ Copied skill from local repo"
 elif command -v curl >/dev/null 2>&1; then
@@ -42,9 +50,14 @@ if [ ! -f "$CLAUDE_MD" ]; then
 elif grep -q "skill: \"ferrograph\"" "$CLAUDE_MD" 2>/dev/null; then
   echo "✓ Skill entry already present in $CLAUDE_MD"
 else
-  # Append under existing ## Skills section if present, else append at end
+  # Insert after ## Skills heading if present, else append new section at end
   if grep -q "^## Skills" "$CLAUDE_MD" 2>/dev/null; then
-    printf '\n%s\n' "$SKILL_ENTRY" >> "$CLAUDE_MD"
+    SKILLS_LINE=$(grep -n "^## Skills" "$CLAUDE_MD" | head -1 | cut -d: -f1)
+    TMPFILE="$(mktemp)"
+    head -n "$SKILLS_LINE" "$CLAUDE_MD" > "$TMPFILE"
+    printf '\n%s\n' "$SKILL_ENTRY" >> "$TMPFILE"
+    tail -n +"$((SKILLS_LINE + 1))" "$CLAUDE_MD" >> "$TMPFILE"
+    mv "$TMPFILE" "$CLAUDE_MD"
   else
     printf '\n## Skills\n\n%s\n' "$SKILL_ENTRY" >> "$CLAUDE_MD"
   fi

--- a/install-claude-skill.sh
+++ b/install-claude-skill.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env sh
+# Install the ferrograph Claude Code skill.
+# Works whether run from a local clone or piped from GitHub:
+#   sh install-claude-skill.sh
+#   curl -fsSL https://raw.githubusercontent.com/GarthDB/ferrograph/main/install-claude-skill.sh | sh
+
+set -e
+
+SKILL_DIR="$HOME/.claude/skills/ferrograph"
+CLAUDE_MD="$HOME/.claude/CLAUDE.md"
+REPO_SKILL="$(cd "$(dirname "$0")" 2>/dev/null && pwd)/.claude/skills/ferrograph/SKILL.md"
+REMOTE_SKILL="https://raw.githubusercontent.com/GarthDB/ferrograph/main/.claude/skills/ferrograph/SKILL.md"
+
+SKILL_ENTRY='### ferrograph
+- **ferrograph** (`~/.claude/skills/ferrograph/SKILL.md`) - Rust code intelligence via knowledge graph. Trigger: `/ferrograph`
+When the user types `/ferrograph`, invoke the Skill tool with `skill: "ferrograph"` before doing anything else.'
+
+# ── Step 1: get the skill file ────────────────────────────────────────────────
+
+mkdir -p "$SKILL_DIR"
+
+if [ -f "$REPO_SKILL" ]; then
+  cp "$REPO_SKILL" "$SKILL_DIR/SKILL.md"
+  echo "✓ Copied skill from local repo"
+elif command -v curl >/dev/null 2>&1; then
+  curl -fsSL "$REMOTE_SKILL" -o "$SKILL_DIR/SKILL.md"
+  echo "✓ Downloaded skill from GitHub"
+elif command -v wget >/dev/null 2>&1; then
+  wget -qO "$SKILL_DIR/SKILL.md" "$REMOTE_SKILL"
+  echo "✓ Downloaded skill from GitHub"
+else
+  echo "Error: cannot fetch skill file — no local repo, curl, or wget found." >&2
+  exit 1
+fi
+
+# ── Step 2: patch ~/.claude/CLAUDE.md ────────────────────────────────────────
+
+if [ ! -f "$CLAUDE_MD" ]; then
+  mkdir -p "$(dirname "$CLAUDE_MD")"
+  printf '# Claude Code Rules\n\n## Skills\n\n%s\n' "$SKILL_ENTRY" > "$CLAUDE_MD"
+  echo "✓ Created $CLAUDE_MD with ferrograph skill entry"
+elif grep -q "skill: \"ferrograph\"" "$CLAUDE_MD" 2>/dev/null; then
+  echo "✓ Skill entry already present in $CLAUDE_MD"
+else
+  # Append under existing ## Skills section if present, else append at end
+  if grep -q "^## Skills" "$CLAUDE_MD" 2>/dev/null; then
+    printf '\n%s\n' "$SKILL_ENTRY" >> "$CLAUDE_MD"
+  else
+    printf '\n## Skills\n\n%s\n' "$SKILL_ENTRY" >> "$CLAUDE_MD"
+  fi
+  echo "✓ Added ferrograph skill entry to $CLAUDE_MD"
+fi
+
+# ── Done ──────────────────────────────────────────────────────────────────────
+
+echo ""
+echo "ferrograph Claude Code skill installed."
+echo "  Skill: $SKILL_DIR/SKILL.md"
+echo "  Config: $CLAUDE_MD"
+echo ""
+echo "Use /ferrograph in any Claude Code session to index and explore a Rust project."
+echo "Note: 'ferrograph claude install' is coming in a future release (see issue #47)."


### PR DESCRIPTION
## Summary

- Add `install-claude-skill.sh` for one-liner Claude Code skill setup (piped from GitHub or run from local clone)
- Add Claude Code skill and CLAUDE.md integration
- Simplify README Claude Code section to use the install script

Stopgap until #47 ships a proper `ferrograph claude install` CLI subcommand.

## Test plan

- [x] `curl -fsSL .../install-claude-skill.sh | sh` installs skill from GitHub
- [x] `sh install-claude-skill.sh` installs from local clone
- [x] Re-running is idempotent (no duplicate CLAUDE.md entries)

🤖 Generated with [Claude Code](https://claude.com/claude-code)